### PR TITLE
Fix gzip_proxied directive for Chrome proxy compatibility

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -49,7 +49,7 @@ http {
     gzip on;
     gzip_vary on;
     gzip_min_length 10240;
-    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css


### PR DESCRIPTION
## Summary
- Adjusts the `gzip_proxied` directive in the Nginx configuration to improve compatibility with Chrome when using the proxy

## Changes

### Nginx Configuration
- Modified `gzip_proxied` directive in `nginx/nginx.conf`:
  - Removed `must-revalidate` from the list of parameters
  - This change helps prevent issues with Chrome proxy configurations that may mishandle certain cache control directives

## Test plan
- [ ] Deploy updated Nginx configuration
- [ ] Verify gzip compression works as expected
- [ ] Test proxy behavior in Chrome to ensure no caching or connection issues
- [ ] Confirm no regressions in other browsers or proxy scenarios

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/08267f1c-bd67-4ef5-b5bc-b290a591e6e8