### PR TITLE
Fix Chrome debugger proxy config and error page nesting in nginx.conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -92,19 +92,19 @@ http {
         location / {
             return 404 "Chrome debugger proxy not configured for this port";
         }
-    }
 
-    # Error page configurations
-    error_page 404 /404.html;
-    error_page 500 502 503 504 /50x.html;
-    
-    location = /404.html {
-        root /usr/share/nginx/html;
-        internal;
-    }
-    
-    location = /50x.html {
-        root /usr/share/nginx/html;
-        internal;
+        # Error page configurations
+        error_page 404 /404.html;
+        error_page 500 502 503 504 /50x.html;
+        
+        location = /404.html {
+            root /usr/share/nginx/html;
+            internal;
+        }
+        
+        location = /50x.html {
+            root /usr/share/nginx/html;
+            internal;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Corrects the configuration for the Chrome debugger proxy in nginx
- Fixes the nesting of error page configurations within the location block

## Changes

### nginx.conf
- Removed misplaced closing brace to properly nest error page configurations inside the Chrome debugger proxy location
- Ensured error pages (404 and 50x) are correctly configured with root and internal directives
- Improved readability and structure of the nginx configuration

## Test plan
- Validate that accessing the Chrome debugger proxy port returns the correct 404 message when not configured
- Confirm that custom error pages (404.html and 50x.html) are served correctly
- Test nginx configuration syntax and reload without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/08267f1c-bd67-4ef5-b5bc-b290a591e6e8