### PR TITLE
Increase nginx types_hash_bucket_size for Chrome proxy fix

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,6 +35,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
+    types_hash_bucket_size 64;
     server_tokens off;
 
     # Buffer sizes for WebSocket optimization


### PR DESCRIPTION
## Summary
- Adjusts the `types_hash_bucket_size` in the nginx configuration to 64
- Aims to fix proxy issues specifically observed with Chrome browsers

## Changes

### nginx Configuration
- Added `types_hash_bucket_size 64;` under the `http` block in `nginx/nginx.conf`
- This change optimizes the hash bucket size for MIME types, potentially improving proxy behavior and compatibility with Chrome

## Test plan
- [ ] Deploy updated nginx configuration
- [ ] Verify that WebSocket connections through the reverse proxy work correctly in Chrome
- [ ] Confirm no regressions in other browsers or proxy functionality
- [ ] Monitor nginx logs for any related errors or warnings after the change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/08267f1c-bd67-4ef5-b5bc-b290a591e6e8